### PR TITLE
Fix Use throwsExceptionWithType

### DIFF
--- a/src/testTestCase/throwsExceptionExpectsADesiredExceptionClassButGotOther.wtest
+++ b/src/testTestCase/throwsExceptionExpectsADesiredExceptionClassButGotOther.wtest
@@ -11,6 +11,6 @@ test "Use throwsExceptionWithType" {
 		assert.throwsExceptionWithType(new BusinessException("hola!"), { => throw new OtherException("hola!") })
 	}
 	catch ex {
-		assert.equals("The exception expected was excepciones.BusinessException but got excepciones.OtherException", ex.getMessage())
+		assert.equals("The exception expected was testTestCase.throwsExceptionExpectsADesiredExceptionClassButGotOther.BusinessException but got testTestCase.throwsExceptionExpectsADesiredExceptionClassButGotOther.OtherException", ex.getMessage())
 	}
 }


### PR DESCRIPTION
- Fix  " Use throwsExceptionWithType"

The original test was: 
```
@Test
	def void throwsExceptionExpectsADesiredExceptionClassButGotOther (){
		#['excepciones' -> '''
			class BusinessException inherits wollok.lang.Exception {
				constructor(_message) {message = _message}
			}
			class OtherException inherits wollok.lang.Exception {
				constructor(_message) {message = _message}
			}
		''',
		'programa' -> '''
			import excepciones.*
			test "Use throwsExceptionWithType" {
				try {
					assert.throwsExceptionWithType(new BusinessException("hola!"), { => throw new OtherException("hola!") })
				}
				catch ex {
					assert.equals("The exception expected was excepciones.BusinessException but got excepciones.OtherException", ex.getMessage())
				}
			}
		'''
		].interpretPropagatingErrors		
	}

```
and I copied "excepciones.BusinessException" but it doesn't exist in the wollok test, the name is "testTestCase.throwsExceptionExpectsADesiredExceptionClassButGotOther.BusinessException"